### PR TITLE
[Maintenance] Removed unnecessary dependency

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -20,8 +20,7 @@
     "dependencies": [
       "fliplet-core",
       "lodash",
-      "handlebars",
-      "tinymce"
+      "handlebars"
     ],
     "assets": [
       "css/build.css",


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/6337

- Because `fliplet-interact` already has `tinymce` as a dependency, it means that the component doesn't need it to function properly.