### PR TITLE
ID-920 [Fix] Avoid text changes being lost when switching away from screen

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -8,7 +8,7 @@
     var PLACEHOLDER_CLASS = 'fl-text-placeholder';
     var WIDGET_INSTANCE_SELECTOR = '[data-fl-widget-instance]';
     var $WYSIWYG_SELECTOR = $('[data-text-id="' + widgetData.id + '"]');
-    var debounceSave = _.debounce(saveChanges, 500);
+    var debounceSave = _.debounce(saveChanges, 500, { leading: true });
     var mode = Fliplet.Env.get('mode');
     var isDev = Fliplet.Env.get('development');
     var isInitialized = false;


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-920

By setting `{ leading: true }` we can make sure that an initial save is triggered as soon as any initial changes are made. A 500ms denounce threshold is then applied after the initial save.

### Follow-up PRs

- ID-920 [Fix] Improve handling of multiple instances to avoid errors #14