### PR TITLE
ID-3811 [Feat] Upgraded for compatibility with TinyMCE 6

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -16,6 +16,7 @@
 
 .mce-content-body *[contentEditable="false"][data-mce-selected] {
   outline: none !important;
+  cursor: default !important;
 }
 
 .fl-wysiwyg-text {

--- a/css/build.css
+++ b/css/build.css
@@ -1,5 +1,6 @@
-.mode-interact .mce-tinymce-inline {
-  display: none;
+.mode-interact .mce-tinymce-inline,
+.mode-interact .tox-tinymce-inline {
+  display: none !important;
 }
 
 .mode-interact .mce-edit-highlight,

--- a/css/build.css
+++ b/css/build.css
@@ -1,5 +1,6 @@
 .mode-interact .mce-tinymce-inline,
-.mode-interact .tox-tinymce-inline {
+.mode-interact .tox-tinymce-inline,
+.mode-interact .tox-tinymce-aux {
   display: none !important;
 }
 

--- a/js/build.js
+++ b/js/build.js
@@ -214,9 +214,8 @@
           object_resizing: false,
           verify_html: false,
           plugins: [
-            'advlist lists link image charmap hr',
-            'searchreplace wordcount insertdatetime table textcolor colorpicker',
-            'noneditable'
+            'advlist', 'lists', 'link', 'image', 'charmap',
+            'searchreplace', 'wordcount', 'insertdatetime', 'table'
           ],
           valid_styles: {
             '*': 'font-family,font-size,font-weight,font-style,text-decoration,text-align,padding,padding-left,padding-right,padding-top,padding-bottom,padding,margin-left,margin-right,margin-top,margin-bottom,margin,display,float,color,background,background-color,background-image,list-style-type,line-height,letter-spacing,width,height,min-width,max-width,min-height,max-height,border,border-top,border-bottom,border-left,border-right,position,opacity,top,left,right,bottom,overflow,z-index',


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-3811

TinyMCE 6 uses a different selector for the inline TinyMCE toolbars. This ensures the toolbars remains invisible (so Studio users can use the toolbar shown in Studio).

This is compatible with both TinyMCE 5 and TinyMCE 6.

Tested against all the TinyMCE toolbar features in Studio (below), which is still using TinyMCE 4.8.1 but doesn't show any compatibility issues.

![image](https://github.com/Fliplet/fliplet-widget-text/assets/290733/6077bde3-cd28-4f27-a3ca-0bd171ec38dc)
