### PR TITLE
ID-3827 [Fix] Initialize children widget to ensure inline links are working when Text component is placed within a helper

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -390,6 +390,8 @@
       }
 
       if (mode !== 'interact') {
+        Fliplet.Widget.initializeChildren($el);
+
         cleanUpContent();
 
         if (!isDev) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-3827

When placed within helpers, `Fliplet.Widget.initializeChildren()` are needed to ensure any inline links are also initialized