### PR TITLE
Release/ID-4895

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -2,6 +2,7 @@
   var editors = {};
 
   Fliplet.Widget.instance('text', function(widgetData) {
+    var el = this;
     var $el = $(this);
     var editor;
     var MIRROR_ELEMENT_CLASS = 'fl-mirror-element';
@@ -189,7 +190,12 @@
     }
 
     function initializeEditor() {
-      editor = tinymce.get($el.attr('id'));
+      // Ensure the element has an ID for TinyMCE
+      if (!el.id) {
+        el.id = 'text-widget-' + widgetData.id;
+      }
+
+      editor = tinymce.get(el.id);
 
       if (editor) {
         return Promise.resolve(editor);
@@ -209,7 +215,8 @@
         // Remove deprecated plugins
         plugins = _.difference(plugins, deprecatedPlugins[tinymceVersion]);
 
-        $el.tinymce({
+        tinymce.init({
+          target: el,
           inline: true,
           menubar: false,
           force_br_newlines: false,

--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -3,9 +3,9 @@ this["Fliplet"]["Widget"] = this["Fliplet"]["Widget"] || {};
 this["Fliplet"]["Widget"]["Templates"] = this["Fliplet"]["Widget"]["Templates"] || {};
 
 this["Fliplet"]["Widget"]["Templates"]["templates.build.content"] = Handlebars.template({"1":function(container,depth0,helpers,partials,data) {
-    return "  <p class=\"fl-text-placeholder\">Click here to start typing...</p>\r\n";
+    return "  <p class=\"fl-text-placeholder\">Click here to start typing...</p>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    return "  <p>&nbsp;</p>\r\n";
+    return "  <p>&nbsp;</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = "";
 


### PR DESCRIPTION
## Summary

- **Fix TinyMCE initialization failure in dynamic components** (e.g. list repeaters): elements rendered inside dynamic containers may lack an `id` attribute, causing `tinymce.get()` and the jQuery `$el.tinymce()` initializer to fail silently.
- Ensures a stable ID is assigned to the element (`text-widget-{widgetData.id}`) before TinyMCE lookup.
- Replaces the jQuery-based `$el.tinymce({...})` call with `tinymce.init({ target: el })`, which binds directly to the DOM element rather than relying on jQuery's ID-based resolution.

## What was happening

When a Text widget was placed inside a dynamic container (e.g. `fl-list-repeater`), the widget element could be rendered without an `id`. This caused two problems:

1. `tinymce.get($el.attr('id'))` returned `null` (since `id` was `undefined`), so the editor was never found even if already initialized.
2. `$el.tinymce({...})` internally depends on the element having an ID to register and retrieve the editor instance — without one, initialization failed.

## How it's fixed

1. A raw DOM reference (`var el = this`) is captured alongside the jQuery wrapper.
2. Before initializing, the code checks `el.id` and assigns a deterministic ID based on `widgetData.id` if missing.
3. `$el.tinymce()` is replaced with `tinymce.init({ target: el })`, which uses the DOM element directly — a more reliable approach that doesn't depend on jQuery's TinyMCE plugin behavior.

## Test plan

- [ ] Place a Text widget inside a dynamic container (list repeater) and verify the editor initializes correctly in Studio edit mode
- [ ] Verify Text widgets outside of dynamic containers still initialize normally
- [ ] Confirm text editing, formatting, and saving work as expected in both scenarios