### PR TITLE
PS-21, PS-48: Fix text formatting not applied and table operations broken

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1091,7 +1091,7 @@
                 const currentHtml = ed.getContent({ format: 'html' }).trim();
                 const isEffectivelyEmpty = currentHtml === '' || currentHtml === '<p></p>' || currentHtml === '<p><br></p>';
 
-                if (!widgetData.html || isEffectivelyEmpty) {
+                if (isEffectivelyEmpty) {
                   // Set a default empty paragraph so formats/tables can be applied at the caret
                   ed.setContent('<p><br></p>');
 
@@ -1374,7 +1374,6 @@
                 // Studio's toolbar sometimes reads state from the selected/root element, not our caret marker.
                 // Apply the mirror element class to the root as well so colors/fonts can be inferred reliably.
                 rootClone.classList.add(MIRROR_ROOT_CLASS);
-                rootClone.classList.add(MIRROR_ELEMENT_CLASS);
 
                 const insertCaretMarker = () => {
                   let rng = null;

--- a/js/build.js
+++ b/js/build.js
@@ -887,6 +887,57 @@
               editor.nodeChanged();
             });
             break;
+          case 'tinymce.updateTable':
+            if (!payload) break;
+            editor = tinymce.activeEditor;
+
+            if (!editor) break;
+
+            editor.undoManager.transact(() => {
+              cancelPendingBlurDisable();
+              Fliplet.Studio.emit('set-wysiwyg-status', true);
+              editor.focus();
+
+              const body = editor.getBody();
+
+              if (!body) return;
+
+              const existingTable = body.querySelector('table');
+
+              if (payload.tableHtml) {
+                if (existingTable) {
+                  // Replace the existing table with the updated one
+                  const tempDiv = document.createElement('div');
+
+                  tempDiv.innerHTML = payload.tableHtml;
+
+                  const newTable = tempDiv.querySelector('table');
+
+                  if (newTable) {
+                    existingTable.parentNode.replaceChild(newTable, existingTable);
+                  }
+                }
+              } else if (existingTable) {
+                // Table was deleted (mceTableDelete)
+                const nextSibling = existingTable.nextElementSibling;
+                const prevSibling = existingTable.previousElementSibling;
+
+                existingTable.parentNode.removeChild(existingTable);
+
+                // Place caret after deletion
+                const caretTarget = nextSibling || prevSibling || body.firstChild;
+
+                if (caretTarget) {
+                  editor.selection.setCursorLocation(caretTarget, 0);
+                }
+              }
+
+              editor.nodeChanged();
+            });
+
+            // Save changes after table update
+            debounceSave();
+            break;
           case 'widgetCancel':
             if (onBlur) {
               editor.hide();


### PR DESCRIPTION
## Summary

### PS-21: Fix text settings not applied unless user types first
- Removed `!widgetData.html` check in the focus handler that was wiping editor content (including formatting) on every refocus. `widgetData.html` stayed falsy for empty/formatting-only editors, causing `$el.text('')` to clear any formatting applied before typing.
- Toolbar sync: cleaned TinyMCE internal attributes (`data-mce-bogus`, `data-mce-type`, `_mce_`-prefixed IDs) from mirror HTML clone so format wrappers survive Studio's `setContent()` parser.
- Removed `MIRROR_ELEMENT_CLASS` from root clone so Studio's `querySelector('.fl-mirror-element')` selects the inner caret marker (inside format wrappers) instead of the root element.

### PS-48: Fix table operations (paste row/col, properties dialogs, properties saving)
- Added `tinymce.updateTable` handler in `studioEventHandler` to receive updated table HTML from Studio and apply it to the iframe editor. This handles property dialog saves and structural table changes (insert/delete row/col, merge/split, paste row/col, delete table).

## Test plan

### PS-21
- [ ] Add a new empty Text component
- [ ] Apply Bold, Italic, Underline, Strikethrough before typing — verify they are applied and persist
- [ ] Apply Heading, Font size, Font color, Background color before typing — verify they are applied
- [ ] Type text after applying styles — verify the styles are applied to the typed text
- [ ] Verify existing text components with content still work normally

### PS-48
- [ ] Insert a table into a Text component
- [ ] Right-click a cell → Copy Row, then Paste Row Before/After — verify paste works
- [ ] Right-click a cell → Copy Column, then Paste Column Before/After — verify paste works
- [ ] Right-click → Cell Properties → change background color → Save — verify changes persist
- [ ] Right-click → Table Properties → change border/width → Save — verify changes persist
- [ ] Insert/delete rows and columns — verify changes reflect and persist
- [ ] Merge and split cells — verify changes reflect and persist
- [ ] Delete table — verify table is removed and content is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)